### PR TITLE
Build mandatory Inception stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 srcs/.env
+srcs/secrets/
+.env

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,54 @@
+COMPOSE_FILE := srcs/docker-compose.yml
+ENV_FILE := srcs/.env
+
+ifneq (,$(wildcard $(ENV_FILE)))
+include $(ENV_FILE)
+export
+endif
+
+LOGIN ?= rapha4lx
+DATA_PATH ?= /home/$(LOGIN)/data
+DATA_DIR ?= $(DATA_PATH)
+COMPOSE := COMPOSE_ENV_FILE=.env docker compose -f $(COMPOSE_FILE) --env-file $(ENV_FILE)
+
+.PHONY: all up build down clean fclean re logs status ps prepare shell-nginx shell-wordpress shell-mariadb check-env
+
+all: up
+
+up: check-env prepare
+	$(COMPOSE) up --build -d
+
+build: check-env prepare
+	$(COMPOSE) build
+
+down: check-env
+	$(COMPOSE) down
+
+clean: down
+
+fclean: check-env
+	$(COMPOSE) down -v --rmi local --remove-orphans
+
+re: fclean up
+
+logs: check-env
+	$(COMPOSE) logs -f
+
+status ps: check-env
+	$(COMPOSE) ps
+
+prepare:
+	mkdir -p $(DATA_DIR)/mariadb $(DATA_DIR)/wordpress
+
+shell-nginx: check-env
+	$(COMPOSE) exec nginx sh
+
+shell-wordpress: check-env
+	$(COMPOSE) exec wordpress sh
+
+shell-mariadb: check-env
+	$(COMPOSE) exec mariadb sh
+
+check-env:
+	@test -f $(ENV_FILE) || \
+		(echo "Missing $(ENV_FILE). Copy srcs/.env.example to $(ENV_FILE) and fill the values."; exit 1)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,92 @@
-# inception
+# Inception
+
+This project builds the mandatory 42 Inception stack with one container per
+service:
+
+- NGINX, exposed only on HTTPS port `443`
+- WordPress running through PHP-FPM on the internal Docker network
+- MariaDB on the internal Docker network
+
+All service images are built from `debian:bookworm`.
+
+## Prerequisites
+
+- Docker
+- Docker Compose plugin
+- A Linux VM or host where Docker can bind port `443`
+- A local domain pointing to `127.0.0.1`
+
+Add the domain to `/etc/hosts`:
+
+```txt
+127.0.0.1 rapha4lx.42.fr
+```
+
+## Environment
+
+Create the runtime environment file:
+
+```sh
+cp srcs/.env.example srcs/.env
+```
+
+Then edit `srcs/.env` and replace every placeholder password. Do not commit
+`srcs/.env`.
+
+Important variables:
+
+- `LOGIN`: your 42 login
+- `DOMAIN_NAME`: local domain served by NGINX
+- `DATA_PATH`: host data directory, normally `/home/<login>/data`
+- `DB_NAME`, `DB_USER`, `DB_PASSWORD`, `DB_ROOT_PASSWORD`
+- `WP_ADMIN_USER`, `WP_ADMIN_PASSWORD`, `WP_ADMIN_EMAIL`
+- `WP_USER`, `WP_USER_PASSWORD`, `WP_USER_EMAIL`
+
+The WordPress administrator username must not contain `admin` or
+`administrator`.
+
+## Data
+
+The Makefile creates the expected host directories:
+
+```txt
+/home/<login>/data/mariadb
+/home/<login>/data/wordpress
+```
+
+MariaDB data and WordPress files persist there through Docker named volumes
+backed by bind mounts.
+
+## Commands
+
+```sh
+make          # create data directories, build, and start the stack
+make build    # build images
+make down     # stop containers
+make re       # rebuild and restart from scratch
+make logs     # follow logs
+make status   # show container status
+make fclean   # remove containers, local images, and Docker volumes
+```
+
+Debug shells are available through:
+
+```sh
+make shell-nginx
+make shell-wordpress
+make shell-mariadb
+```
+
+## Validation
+
+After `make`, open:
+
+```txt
+https://rapha4lx.42.fr
+```
+
+The generated TLS certificate is self-signed, so the browser may show a local
+certificate warning.
+
+Use [docs/evaluation-checklist.md](docs/evaluation-checklist.md) before peer
+evaluation.

--- a/docs/evaluation-checklist.md
+++ b/docs/evaluation-checklist.md
@@ -1,0 +1,56 @@
+# Inception Evaluation Checklist
+
+## Startup
+
+- `srcs/.env` exists and contains non-placeholder passwords.
+- `/etc/hosts` maps the configured domain to `127.0.0.1`.
+- `make` builds all three custom images and starts the stack.
+- `docker compose -f srcs/docker-compose.yml ps` shows `nginx`, `wordpress`,
+  and `mariadb`.
+
+## Mandatory Architecture
+
+- NGINX is the only service exposing a host port.
+- MariaDB has no `ports:` mapping.
+- WordPress runs PHP-FPM only.
+- Each mandatory service has its own container.
+- The compose file uses a custom Docker network.
+- No service uses `network_mode: host`, `links`, or `--link`.
+
+## Images and Runtime
+
+- All Dockerfiles start from `debian:bookworm`.
+- No mandatory service uses a ready-made `mariadb`, `wordpress`, or `nginx`
+  Docker Hub service image as its base.
+- Entrypoints finish setup and `exec` the foreground service process.
+- No Dockerfile or entrypoint uses `tail -f`, `sleep infinity`, or an infinite
+  keepalive loop.
+
+## WordPress
+
+- `https://<login>.42.fr` serves the WordPress site.
+- WordPress connects to MariaDB through the internal Docker network.
+- The configured administrator account can log in.
+- A second non-admin WordPress user exists.
+- The administrator username does not contain `admin` or `administrator`.
+
+## TLS
+
+- NGINX listens on port `443`.
+- TLS is restricted to TLSv1.2 and TLSv1.3.
+- HTTP is not exposed as the mandatory public entrypoint.
+
+## Persistence
+
+- Create or modify a WordPress page.
+- Run `make down`.
+- Run `make`.
+- Confirm the WordPress content is still present.
+- Confirm MariaDB data is under `/home/<login>/data/mariadb`.
+- Confirm WordPress files are under `/home/<login>/data/wordpress`.
+
+## Cleanup
+
+- `make down` stops the stack cleanly.
+- `make re` rebuilds and starts the stack again.
+- `make logs` gives useful logs for all services.

--- a/srcs/.env.example
+++ b/srcs/.env.example
@@ -1,0 +1,16 @@
+LOGIN=rapha4lx
+DOMAIN_NAME=rapha4lx.42.fr
+DATA_PATH=/home/rapha4lx/data
+
+DB_NAME=wordpress
+DB_USER=wp_user
+DB_PASSWORD=change_this_database_password
+DB_ROOT_PASSWORD=change_this_root_password
+
+WP_TITLE=Inception
+WP_ADMIN_USER=siteowner
+WP_ADMIN_PASSWORD=change_this_wordpress_owner_password
+WP_ADMIN_EMAIL=siteowner@example.com
+WP_USER=editor
+WP_USER_PASSWORD=change_this_wordpress_user_password
+WP_USER_EMAIL=editor@example.com

--- a/srcs/docker-compose.yml
+++ b/srcs/docker-compose.yml
@@ -1,25 +1,66 @@
-version: '3.8'
-
 services:
   mariadb:
-    build: ./requirements/mariadb
+    build:
+      context: ./requirements/mariadb
     container_name: mariadb
+    image: mariadb
     env_file:
-      - .env
-    restart: unless-stopped
+      - ${COMPOSE_ENV_FILE:-.env}
+    restart: always
     volumes:
       - mariadb_data:/var/lib/mysql
     networks:
       - inception
-    ports:
-      - "3306:3306"
 
-# Adicione outros serviços (nginx, wordpress, etc) conforme necessário
+  wordpress:
+    build:
+      context: ./requirements/wordpress
+    container_name: wordpress
+    image: wordpress
+    env_file:
+      - ${COMPOSE_ENV_FILE:-.env}
+    restart: always
+    depends_on:
+      - mariadb
+    volumes:
+      - wordpress_data:/var/www/html
+    networks:
+      - inception
+
+  nginx:
+    build:
+      context: ./requirements/nginx
+    container_name: nginx
+    image: nginx
+    env_file:
+      - ${COMPOSE_ENV_FILE:-.env}
+    restart: always
+    depends_on:
+      - wordpress
+    ports:
+      - "443:443"
+    volumes:
+      - wordpress_data:/var/www/html:ro
+    networks:
+      - inception
 
 volumes:
   mariadb_data:
+    name: mariadb_data
     driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${DATA_PATH}/mariadb
+  wordpress_data:
+    name: wordpress_data
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${DATA_PATH}/wordpress
 
 networks:
   inception:
+    name: inception
     driver: bridge

--- a/srcs/requirements/mariadb/Dockerfile
+++ b/srcs/requirements/mariadb/Dockerfile
@@ -1,14 +1,18 @@
-# Utiliza a imagem oficial do MariaDB
-FROM mariadb:11.3
+FROM debian:bookworm
 
-# Copia arquivos de configuração personalizados, se existirem
-# COPY conf/my.cnf /etc/mysql/my.cnf
-# COPY tools/init.sql /docker-entrypoint-initdb.d/
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends mariadb-server mariadb-client \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& rm -rf /var/lib/mysql/* \
+	&& mkdir -p /run/mysqld \
+	&& chown -R mysql:mysql /run/mysqld /var/lib/mysql
 
-# Define variáveis de ambiente (serão sobrescritas pelo docker-compose/.env)
-ENV MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
-ENV MYSQL_DATABASE=${MYSQL_DATABASE}
-ENV MYSQL_USER=${MYSQL_USER}
-ENV MYSQL_PASSWORD=${MYSQL_PASSWORD}
+COPY conf/50-server.cnf /etc/mysql/mariadb.conf.d/50-server.cnf
+COPY tools/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
 
 EXPOSE 3306
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["mysqld", "--user=mysql", "--console"]

--- a/srcs/requirements/mariadb/conf/50-server.cnf
+++ b/srcs/requirements/mariadb/conf/50-server.cnf
@@ -1,0 +1,6 @@
+[mysqld]
+bind-address = 0.0.0.0
+port = 3306
+datadir = /var/lib/mysql
+socket = /run/mysqld/mysqld.sock
+skip-name-resolve

--- a/srcs/requirements/mariadb/tools/entrypoint.sh
+++ b/srcs/requirements/mariadb/tools/entrypoint.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -eu
+
+require_var() {
+	if [ -z "${1:-}" ]; then
+		echo "Missing required environment variable: $2" >&2
+		exit 1
+	fi
+}
+
+require_var "${DB_NAME:-}" "DB_NAME"
+require_var "${DB_USER:-}" "DB_USER"
+require_var "${DB_PASSWORD:-}" "DB_PASSWORD"
+require_var "${DB_ROOT_PASSWORD:-}" "DB_ROOT_PASSWORD"
+
+mkdir -p /run/mysqld /var/lib/mysql
+chown -R mysql:mysql /run/mysqld /var/lib/mysql
+
+if [ ! -d /var/lib/mysql/mysql ]; then
+	mariadb-install-db --user=mysql --datadir=/var/lib/mysql --skip-test-db >/dev/null
+
+	mysqld --user=mysql --datadir=/var/lib/mysql --skip-networking \
+		--socket=/run/mysqld/mysqld.sock &
+	pid="$!"
+
+	i=0
+	until mariadb-admin --socket=/run/mysqld/mysqld.sock ping >/dev/null 2>&1; do
+		i=$((i + 1))
+		if [ "$i" -gt 60 ]; then
+			echo "MariaDB bootstrap server did not start" >&2
+			exit 1
+		fi
+		sleep 1
+	done
+
+	mariadb --socket=/run/mysqld/mysqld.sock <<-SQL
+		ALTER USER 'root'@'localhost' IDENTIFIED BY '${DB_ROOT_PASSWORD}';
+		DROP USER IF EXISTS ''@'localhost';
+		DROP USER IF EXISTS ''@'%';
+		DROP DATABASE IF EXISTS test;
+		CREATE DATABASE IF NOT EXISTS \`${DB_NAME}\`;
+		CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASSWORD}';
+		GRANT ALL PRIVILEGES ON \`${DB_NAME}\`.* TO '${DB_USER}'@'%';
+		FLUSH PRIVILEGES;
+	SQL
+
+	mariadb-admin --socket=/run/mysqld/mysqld.sock \
+		-u root -p"${DB_ROOT_PASSWORD}" shutdown
+	wait "$pid"
+fi
+
+exec "$@"

--- a/srcs/requirements/nginx/Dockerfile
+++ b/srcs/requirements/nginx/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:bookworm
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		ca-certificates \
+		gettext-base \
+		nginx \
+		openssl \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /etc/nginx/ssl /var/www/html
+
+COPY conf/inception.conf.template /etc/nginx/templates/inception.conf.template
+COPY tools/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+EXPOSE 443
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["nginx", "-g", "daemon off;"]

--- a/srcs/requirements/nginx/conf/inception.conf.template
+++ b/srcs/requirements/nginx/conf/inception.conf.template
@@ -1,0 +1,24 @@
+server {
+	listen 443 ssl;
+	listen [::]:443 ssl;
+	server_name ${DOMAIN_NAME};
+
+	root /var/www/html;
+	index index.php index.html;
+
+	ssl_certificate /etc/nginx/ssl/inception.crt;
+	ssl_certificate_key /etc/nginx/ssl/inception.key;
+	ssl_protocols TLSv1.2 TLSv1.3;
+	ssl_prefer_server_ciphers off;
+
+	location / {
+		try_files $uri $uri/ /index.php?$args;
+	}
+
+	location ~ \.php$ {
+		include fastcgi_params;
+		fastcgi_pass wordpress:9000;
+		fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+		fastcgi_param HTTPS on;
+	}
+}

--- a/srcs/requirements/nginx/tools/entrypoint.sh
+++ b/srcs/requirements/nginx/tools/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${DOMAIN_NAME:-}" ]; then
+	echo "Missing required environment variable: DOMAIN_NAME" >&2
+	exit 1
+fi
+
+mkdir -p /etc/nginx/ssl /var/www/html
+
+if [ ! -f /etc/nginx/ssl/inception.crt ] || [ ! -f /etc/nginx/ssl/inception.key ]; then
+	openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
+		-keyout /etc/nginx/ssl/inception.key \
+		-out /etc/nginx/ssl/inception.crt \
+		-subj "/CN=${DOMAIN_NAME}" >/dev/null 2>&1
+fi
+
+envsubst '${DOMAIN_NAME}' \
+	< /etc/nginx/templates/inception.conf.template \
+	> /etc/nginx/sites-available/default
+
+exec "$@"

--- a/srcs/requirements/wordpress/Dockerfile
+++ b/srcs/requirements/wordpress/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:bookworm
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends \
+		ca-certificates \
+		curl \
+		mariadb-client \
+		php8.2-cli \
+		php8.2-curl \
+		php8.2-fpm \
+		php8.2-gd \
+		php8.2-intl \
+		php8.2-mbstring \
+		php8.2-mysql \
+		php8.2-xml \
+		php8.2-zip \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& curl -fsSL https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /usr/local/bin/wp \
+	&& chmod +x /usr/local/bin/wp \
+	&& mkdir -p /run/php /var/www/html \
+	&& chown -R www-data:www-data /run/php /var/www/html
+
+COPY conf/www.conf /etc/php/8.2/fpm/pool.d/www.conf
+COPY tools/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+WORKDIR /var/www/html
+
+EXPOSE 9000
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["php-fpm8.2", "-F"]

--- a/srcs/requirements/wordpress/conf/www.conf
+++ b/srcs/requirements/wordpress/conf/www.conf
@@ -1,0 +1,13 @@
+[www]
+user = www-data
+group = www-data
+
+listen = 0.0.0.0:9000
+
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+
+clear_env = no

--- a/srcs/requirements/wordpress/tools/entrypoint.sh
+++ b/srcs/requirements/wordpress/tools/entrypoint.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+set -eu
+
+require_var() {
+	if [ -z "${1:-}" ]; then
+		echo "Missing required environment variable: $2" >&2
+		exit 1
+	fi
+}
+
+require_var "${DOMAIN_NAME:-}" "DOMAIN_NAME"
+require_var "${DB_NAME:-}" "DB_NAME"
+require_var "${DB_USER:-}" "DB_USER"
+require_var "${DB_PASSWORD:-}" "DB_PASSWORD"
+require_var "${WP_TITLE:-}" "WP_TITLE"
+require_var "${WP_ADMIN_USER:-}" "WP_ADMIN_USER"
+require_var "${WP_ADMIN_PASSWORD:-}" "WP_ADMIN_PASSWORD"
+require_var "${WP_ADMIN_EMAIL:-}" "WP_ADMIN_EMAIL"
+require_var "${WP_USER:-}" "WP_USER"
+require_var "${WP_USER_PASSWORD:-}" "WP_USER_PASSWORD"
+require_var "${WP_USER_EMAIL:-}" "WP_USER_EMAIL"
+
+admin_name="$(printf '%s' "$WP_ADMIN_USER" | tr '[:upper:]' '[:lower:]')"
+case "$admin_name" in
+	*admin*|*administrator*)
+		echo "WP_ADMIN_USER must not contain admin or administrator" >&2
+		exit 1
+		;;
+esac
+
+mkdir -p /run/php /var/www/html
+chown -R www-data:www-data /run/php /var/www/html
+
+i=0
+until mariadb-admin ping -h mariadb -u "$DB_USER" -p"$DB_PASSWORD" >/dev/null 2>&1; do
+	i=$((i + 1))
+	if [ "$i" -gt 60 ]; then
+		echo "MariaDB is not reachable from WordPress" >&2
+		exit 1
+	fi
+	sleep 1
+done
+
+if [ ! -f /var/www/html/wp-settings.php ]; then
+	wp core download --path=/var/www/html --allow-root
+fi
+
+if [ ! -f /var/www/html/wp-config.php ]; then
+	wp config create \
+		--path=/var/www/html \
+		--dbname="$DB_NAME" \
+		--dbuser="$DB_USER" \
+		--dbpass="$DB_PASSWORD" \
+		--dbhost="mariadb:3306" \
+		--skip-check \
+		--allow-root
+fi
+
+if ! wp core is-installed --path=/var/www/html --allow-root >/dev/null 2>&1; then
+	wp core install \
+		--path=/var/www/html \
+		--url="https://${DOMAIN_NAME}" \
+		--title="$WP_TITLE" \
+		--admin_user="$WP_ADMIN_USER" \
+		--admin_password="$WP_ADMIN_PASSWORD" \
+		--admin_email="$WP_ADMIN_EMAIL" \
+		--allow-root
+fi
+
+if ! wp user get "$WP_USER" --path=/var/www/html --allow-root >/dev/null 2>&1; then
+	wp user create "$WP_USER" "$WP_USER_EMAIL" \
+		--path=/var/www/html \
+		--user_pass="$WP_USER_PASSWORD" \
+		--role=author \
+		--allow-root
+fi
+
+chown -R www-data:www-data /var/www/html
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Add root Makefile, env template, evaluation checklist, and defense-ready README
- Implement the mandatory Docker Compose architecture with NGINX, WordPress/PHP-FPM, and MariaDB
- Build all mandatory services from Debian-based project Dockerfiles with service-local config and entrypoint scripts
- Add persistent MariaDB and WordPress volumes mapped through the expected host data path
- Restrict the public surface to HTTPS on port 443 and keep MariaDB internal-only

## Validation

- `docker compose -f srcs/docker-compose.yml --env-file srcs/.env.example config`
- `sh -n` on all service entrypoint scripts
- `git diff --check`
- Built all three service images
- Runtime smoke test with temporary `/tmp/inception-test-data2`: MariaDB initialized DB/user, WordPress created admin plus normal user, and NGINX returned `HTTP/1.1 200 OK` over HTTPS

Closes #1
Closes #2
Closes #3
Closes #4
Closes #5
Closes #6
Closes #7
Closes #8
Closes #9
Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15